### PR TITLE
TX_ALERT transaction details

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1967,8 +1967,13 @@ static void ListTransactions(interfaces::Chain::Lock& locked_chain, CWallet* con
 
     bool involvesWatchonly = wtx.IsFromMe(ISMINE_WATCH_ONLY);
 
+    CBlockIndex* blockindex = nullptr;
+    if(!wtx.InMempool()) {
+        blockindex = LookupBlockIndex(wtx.hashBlock);
+    }
+
     vaulttxntype txType = GetVaultTxTypeNonContextual(*wtx.tx);
-    vaulttxnstatus txStatus = TX_UNKNOWN;
+    vaulttxnstatus txStatus = GetTransactionStatus(wtx.GetHash(), Params().GetConsensus(), txType, blockindex);
 
     // Sent
     if (!filter_label)
@@ -1988,11 +1993,6 @@ static void ListTransactions(interfaces::Chain::Lock& locked_chain, CWallet* con
             entry.pushKV("vout", s.vout);
             entry.pushKV("fee", ValueFromAmount(-nFee));
             if (fLong) {
-                CBlockIndex* blockindex = nullptr;
-                if(!wtx.InMempool()) {
-                    blockindex = LookupBlockIndex(wtx.hashBlock);
-                }
-                txStatus = GetTransactionStatus(wtx.GetHash(), Params().GetConsensus(), txType, blockindex);
                 WalletTxToJSON(pwallet->chain(), locked_chain, wtx, txType, txStatus, entry);
             }
             entry.pushKV("abandoned", wtx.isAbandoned());
@@ -2036,11 +2036,6 @@ static void ListTransactions(interfaces::Chain::Lock& locked_chain, CWallet* con
             }
             entry.pushKV("vout", r.vout);
             if (fLong) {
-                CBlockIndex* blockindex = nullptr;
-                if(!wtx.InMempool()) {
-                    blockindex = LookupBlockIndex(wtx.hashBlock);
-                }
-                txStatus = GetTransactionStatus(wtx.GetHash(), Params().GetConsensus(), txType, blockindex);
                 WalletTxToJSON(pwallet->chain(), locked_chain, wtx, txType, txStatus, entry);
             }
             if (txType != TX_ALERT || (txType == TX_ALERT && txStatus != TX_UNKNOWN))


### PR DESCRIPTION
RPC method `gettransaction` doesn't return any details for transactions with `TX_ALERT` type.
This is because the transaction status is not being recognized correctly (it is `TX_UNKNOWN` by default and it is being changed only if `fLong` option is `true`, but a passed value is `false` in the `gettransaction` method).

Steps to reproduce:
1. Create `TX_ALERT` transaction to your node's wallet
2. Try to get this transaction using `gettransaction` method

Expected behavior: there are details with category `receive`
Current behavior: details list is empty