### PR TITLE
improvement: getblock - Add tx type/status to getblock verbose output 

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -165,6 +165,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
     result.pushKV("versionHex", strprintf("%08x", block.nVersion));
     result.pushKV("merkleroot", block.hashMerkleRoot.GetHex());
     result.pushKV("alertmerkleroot", GetCoinbaseAlertMerkleRoot(block).GetHex());
+
     UniValue txs(UniValue::VARR);
     for(const auto& tx : block.vtx)
     {
@@ -174,16 +175,11 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
             TxToUniv(*tx, uint256(), objTx, true, RPCSerializationFlags());
 
             vaulttxntype txType = GetVaultTxTypeNonContextual(*tx);
-            auto getTxTypeName = [] (const vaulttxntype txType) -> std::string {
-                switch (txType) {
-                    case TX_ALERT: return "TX_ALERT";
-                    case TX_INSTANT: return "TX_INSTANT";
-                    case TX_RECOVERY: return "TX_RECOVERY";
-                    case TX_INVALID: return "TX_INVALID";
-                    default: return "TX_NONVAULT";
-                }
-            };
+            vaulttxnstatus txStatus = GetTransactionStatus(tx->GetHash(), Params().GetConsensus(), txType);
+
             objTx.pushKV("type", getTxTypeName(txType));
+            if (txStatus != TX_UNKNOWN)
+                objTx.pushKV("status", getTxStatusName(txStatus));
 
             txs.push_back(objTx);
         }
@@ -198,6 +194,14 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
         {
             UniValue objATx(UniValue::VOBJ);
             TxToUniv(*atx, uint256(), objATx, true, RPCSerializationFlags());
+
+            vaulttxntype txType = GetVaultTxTypeNonContextual(*atx);
+            vaulttxnstatus txStatus = GetTransactionStatus(atx->GetHash(), Params().GetConsensus(), txType);
+
+            objATx.pushKV("type", getTxTypeName(txType));
+            if (txStatus != TX_UNKNOWN)
+                objATx.pushKV("status", getTxStatusName(txStatus));
+
             atxs.push_back(objATx);
         }
         else

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -172,6 +172,19 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
         {
             UniValue objTx(UniValue::VOBJ);
             TxToUniv(*tx, uint256(), objTx, true, RPCSerializationFlags());
+
+            vaulttxntype txType = GetVaultTxTypeNonContextual(*tx);
+            auto getTxTypeName = [] (const vaulttxntype txType) -> std::string {
+                switch (txType) {
+                    case TX_ALERT: return "TX_ALERT";
+                    case TX_INSTANT: return "TX_INSTANT";
+                    case TX_RECOVERY: return "TX_RECOVERY";
+                    case TX_INVALID: return "TX_INVALID";
+                    default: return "TX_NONVAULT";
+                }
+            };
+            objTx.pushKV("type", getTxTypeName(txType));
+
             txs.push_back(objTx);
         }
         else

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -48,25 +48,7 @@ void TxToJSON(const CBaseTransaction& tx, const uint256 hashBlock, const vaulttx
     // data into the returned UniValue.
     TxToUniv(tx, uint256(), entry, true, RPCSerializationFlags());
 
-    auto getTxTypeName = [] (const vaulttxntype txType) -> std::string {
-        switch (txType) {
-            case TX_ALERT: return "TX_ALERT";
-            case TX_INSTANT: return "TX_INSTANT";
-            case TX_RECOVERY: return "TX_RECOVERY";
-            case TX_INVALID: return "TX_INVALID";
-            default: return "TX_NONVAULT";
-        }
-    };
     entry.pushKV("type", getTxTypeName(txType));
-
-    auto getTxStatusName = [] (const vaulttxnstatus txStatus) -> std::string {
-        switch (txStatus) {
-            case TX_PENDING: return "PENDING";
-            case TX_CONFIRMED: return "CONFIRMED";
-            case TX_RECOVERED: return "RECOVERED";
-            default: return "INVALID";
-        }
-    };
     if (txStatus != TX_UNKNOWN)
     	entry.pushKV("status", getTxStatusName(txStatus));
 
@@ -2171,4 +2153,25 @@ void RegisterRawTransactionRPCCommands(CRPCTable &t)
 {
     for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
         t.appendCommand(commands[vcidx].name, &commands[vcidx]);
+}
+
+std::string getTxStatusName(const vaulttxnstatus txStatus)
+{
+    switch (txStatus) {
+    case TX_PENDING: return "PENDING";
+    case TX_CONFIRMED: return "CONFIRMED";
+    case TX_RECOVERED: return "RECOVERED";
+    default: return "INVALID";
+    }
+}
+
+std::string getTxTypeName(const vaulttxntype txType)
+{
+    switch (txType) {
+    case TX_ALERT: return "TX_ALERT";
+    case TX_INSTANT: return "TX_INSTANT";
+    case TX_RECOVERY: return "TX_RECOVERY";
+    case TX_INVALID: return "TX_INVALID";
+    default: return "TX_NONVAULT";
+    }
 }

--- a/src/rpc/rawtransaction.h
+++ b/src/rpc/rawtransaction.h
@@ -24,4 +24,7 @@ UniValue SignTransaction(interfaces::Chain& chain, CMutableTransaction& mtx, con
 /** Create a transaction from univalue parameters */
 CMutableTransaction ConstructTransaction(const UniValue& inputs_in, const UniValue& outputs_in, const UniValue& locktime, const UniValue& rbf);
 
+std::string getTxStatusName(const vaulttxnstatus txStatus);
+std::string getTxTypeName(const vaulttxntype txType);;
+
 #endif // BITCOIN_RPC_RAWTRANSACTION_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -178,25 +178,7 @@ static void WalletTxToJSON(interfaces::Chain& chain, interfaces::Chain::Lock& lo
     for (const std::pair<const std::string, std::string>& item : wtx.mapValue)
         entry.pushKV(item.first, item.second);
 
-    auto getTxTypeName = [] (const vaulttxntype txType) -> std::string {
-        switch (txType) {
-            case TX_ALERT: return "TX_ALERT";
-            case TX_INSTANT: return "TX_INSTANT";
-            case TX_RECOVERY: return "TX_RECOVERY";
-            case TX_INVALID: return "TX_INVALID";
-            default: return "TX_NONVAULT";
-        }
-    };
     entry.pushKV("type", getTxTypeName(txType));
-
-    auto getTxStatusName = [] (const vaulttxnstatus txStatus) -> std::string {
-        switch (txStatus) {
-            case TX_PENDING: return "PENDING";
-            case TX_CONFIRMED: return "CONFIRMED";
-            case TX_RECOVERED: return "RECOVERED";
-            default: return "UNKNOWN";
-        }
-    };
     entry.pushKV("status", getTxStatusName(txStatus));
 }
 


### PR DESCRIPTION
calling 
```
bvault-cli getrawtransaction TXID 1
```
returns tx type and tx status, while calling 
```
bvault-cli getblock BLOCKHASH 2
```
returns decoded transactions, but without tx type/status information included. It would be helpful to have txtype/status in getblock as well for 
