### PR TITLE
Add %w param to walletnotify call

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -10,6 +10,8 @@
 #include <serialize.h>
 #include <util/strencodings.h>
 
+#include <boost/algorithm/string/replace.hpp>
+
 #include <stdarg.h>
 
 #if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
@@ -1118,6 +1120,15 @@ fs::path GetSpecialFolderPath(int nFolder, bool fCreate)
 
     LogPrintf("SHGetSpecialFolderPathW() failed, could not obtain requested path.\n");
     return fs::path("");
+}
+#endif
+
+#ifndef WIN32
+std::string ShellEscape(const std::string& arg)
+{
+    std::string escaped = arg;
+    boost::replace_all(escaped, "'", "'\"'\"'");
+    return "'" + escaped + "'";
 }
 #endif
 

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -91,6 +91,9 @@ fs::path GetConfigFile(const std::string& confPath);
 #ifdef WIN32
 fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
+#ifndef WIN32
+std::string ShellEscape(const std::string& arg);
+#endif
 void runCommand(const std::string& strCommand);
 
 /**

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1949,8 +1949,13 @@ static void ListTransactions(interfaces::Chain::Lock& locked_chain, CWallet* con
 
     bool involvesWatchonly = wtx.IsFromMe(ISMINE_WATCH_ONLY);
 
+    CBlockIndex* blockindex = nullptr;
+    if(!wtx.InMempool()) {
+        blockindex = LookupBlockIndex(wtx.hashBlock);
+    }
+
     vaulttxntype txType = GetVaultTxTypeNonContextual(*wtx.tx);
-    vaulttxnstatus txStatus = TX_UNKNOWN;
+    vaulttxnstatus txStatus = GetTransactionStatus(wtx.GetHash(), Params().GetConsensus(), txType, blockindex);
 
     // Sent
     if (!filter_label)
@@ -1970,11 +1975,6 @@ static void ListTransactions(interfaces::Chain::Lock& locked_chain, CWallet* con
             entry.pushKV("vout", s.vout);
             entry.pushKV("fee", ValueFromAmount(-nFee));
             if (fLong) {
-                CBlockIndex* blockindex = nullptr;
-                if(!wtx.InMempool()) {
-                    blockindex = LookupBlockIndex(wtx.hashBlock);
-                }
-                txStatus = GetTransactionStatus(wtx.GetHash(), Params().GetConsensus(), txType, blockindex);
                 WalletTxToJSON(pwallet->chain(), locked_chain, wtx, txType, txStatus, entry);
             }
             entry.pushKV("abandoned", wtx.isAbandoned());
@@ -2018,11 +2018,6 @@ static void ListTransactions(interfaces::Chain::Lock& locked_chain, CWallet* con
             }
             entry.pushKV("vout", r.vout);
             if (fLong) {
-                CBlockIndex* blockindex = nullptr;
-                if(!wtx.InMempool()) {
-                    blockindex = LookupBlockIndex(wtx.hashBlock);
-                }
-                txStatus = GetTransactionStatus(wtx.GetHash(), Params().GetConsensus(), txType, blockindex);
                 WalletTxToJSON(pwallet->chain(), locked_chain, wtx, txType, txStatus, entry);
             }
             if (txType != TX_ALERT || (txType == TX_ALERT && txStatus != TX_UNKNOWN))

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1003,6 +1003,14 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
     if (!strCmd.empty())
     {
         boost::replace_all(strCmd, "%s", wtxIn.GetHash().GetHex());
+#ifndef WIN32
+        // Substituting the wallet name isn't currently supported on windows
+        // because windows shell escaping has not been implemented yet:
+        // https://github.com/bitcoin/bitcoin/pull/13339#issuecomment-537384875
+        // A few ways it could be implemented in the future are described in:
+        // https://github.com/bitcoin/bitcoin/pull/13339#issuecomment-461288094
+        boost::replace_all(strCmd, "%w", ShellEscape(GetName()));
+#endif
         std::thread t(runCommand, strCmd);
         t.detach(); // thread runs free
     }


### PR DESCRIPTION
Hi! This PR enables a wallet notify call such as this:
- `walletnotify.sh %s %w` 

%w will be replaced by the name of the wallet that is being notified.
This feature is already supported in Bitcoin (and Elcash). I pretty much copy pasted what they had there. As in these other cases, this feature is not supported on Windows.